### PR TITLE
Add opam, dune config to make package installable

### DIFF
--- a/hardcaml_arty.opam
+++ b/hardcaml_arty.opam
@@ -1,0 +1,14 @@
+opam-version: "2.0"
+maintainer: "fyquah"
+authors: "fyquah"
+homepage: "https://github.com/fyquah/hardcaml_arty"
+bug-reports: "https://github.com/fyquah/hardcaml_arty/issues"
+dev-repo: "git+https://github.com/fyquah/hardcaml_arty.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base"
+  "hardcaml"
+]
+synopsis: "A library to use Digilent Arty A7 Boards with Hardcaml"

--- a/src/infrastructure/dune
+++ b/src/infrastructure/dune
@@ -1,4 +1,5 @@
 (library
  (name hardcaml_arty)
+ (public_name hardcaml_arty)
  (libraries base hardcaml)
  (preprocess (pps ppx_deriving_hardcaml ppx_jane)))


### PR DESCRIPTION
With these changes, the package should be installable from GitHub or via a path pin.